### PR TITLE
Fix: Invoke Step Functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,14 +39,18 @@ class ServerlessPlugin {
    * A custom request template is used to send the state machine name and starting
    * state's name to the lambda's execution
    */
-  createEndpoints() {
+  async createEndpoints() {
     // object key in the service's custom data for config values
     const SERVERLESS_OFFLINE_STEP_FUNCTIONS = 'serverless-offline-step-functions';
     const functions = this.serverless.service.functions;
+
+    await this.getServerlessStepFunctionsPlugin().yamlParse();
+
     if (typeof this.serverless.service.stepFunctions.stateMachines === 'undefined') {
         console.warn(`${this.logPrefix}: No state machines found! Please check your stepFunctions configuration for the 'stateMachines' object.`);
         return false;
     }
+
     _.forEach(this.serverless.service.stepFunctions.stateMachines, (stateMachine, stateMachineName) => {
         if (typeof stateMachine.definition === 'undefined') {
             console.warn(`${this.logPrefix}: no 'definition' found for state machine ${stateMachineName}. Continuing to next state machine.`);
@@ -119,6 +123,17 @@ class ServerlessPlugin {
             }
         });
     });
+  }
+
+  /**
+   * Get Serverless Step Functions plugin object.
+   */
+  getServerlessStepFunctionsPlugin() {
+    const filteredPlugins = this.serverless.pluginManager.plugins.filter(
+      plugin => plugin.constructor.name == 'ServerlessStepFunctions'
+    );
+
+    return filteredPlugins[0];
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -147,6 +147,8 @@ class ServerlessPlugin {
    * Solves the Lambda name for Fn::Get or ARN strings.
    */
   getLambdaName(resource) {
+    if(!resource) throw new Error(`No resource was provided`);
+
     const extractors = {
       static: this.serverless.providers.aws.naming.extractLambdaNameFromArn,
       dynamic: this.extractLambdaNameFromFunction,

--- a/src/state-machine-executor.js
+++ b/src/state-machine-executor.js
@@ -40,7 +40,7 @@ class StateMachineExecutor {
      */
     spawnProcess(stateInfo, input, context, callback = null) {
         console.log(`* * * * * ${this.currentStateName} * * * * *`);
-        console.log('input: ', input);
+        console.log('input: \n', JSON.stringify(input, 0, 2), '\n');
         // This will be used as the parent node key for when the process
         // finishes and its output needs to be processed.
         const outputKey = `sf-${Date.now()}`;
@@ -105,7 +105,7 @@ class StateMachineExecutor {
                 // newEvent.stateName = stateInfo.Next;
                 this.currentStateName = stateInfo.Next;
                 stateInfo = this.stateMachineJSON.stateMachines[this.stateMachineName].definition.States[stateInfo.Next];
-                console.log('output: ', output);
+                console.log('output: \n', JSON.stringify(output, 0, 2), '\n');
                 this.spawnProcess(stateInfo, output, context, callback);
             });
     }
@@ -125,7 +125,7 @@ class StateMachineExecutor {
             console.log(`${logPrefix} input:`, input);
         }
 
-        console.log(`${logPrefix} output:`, output);
+        console.log(`${logPrefix} output: \n`, JSON.stringify(output, 0, 2), '\n');
         return true;
     }
 

--- a/src/state-machine-executor.js
+++ b/src/state-machine-executor.js
@@ -153,7 +153,7 @@ class StateMachineExecutor {
                 // TODO: catch, retry
                 // This will spin up a node child process to fire off the handler function of the given lambda
                 // the output of the lambda is placed into a JSON object with the outputKey generated above as
-                // the parent node and piped to stdout for processing. This is done so other callbacconsole.logs are not
+                // the parent node and piped to stdout for processing. This is done so other callback console.logs are not
                 // processed by this plugin.
                 // process.exit(0) must be called in .then because a child process will not exit if it has connected
                 // to another resource, such as a database or redis, which may be a source of future events.

--- a/src/step-functions-api-simulator.js
+++ b/src/step-functions-api-simulator.js
@@ -35,14 +35,14 @@ module.exports = (serverless) => {
                     const sme = new StateMachineExecutor(machineKey, machine.definition.StartAt, { [machineKey]: machine });
 
                     // TODO: check integration type to set input properly (i.e. lambda vs. sns)
-                    sme.spawnProcess(currentState, JSON.parse(data.input), {}, () => true);
+                    sme.spawnProcess(currentState, data.input, {}, (err, result) => result);
                     startDate = sme.startDate;
                     exeArn = sme.executionArn;
                 }
             });
             // per docs, step execution response includes the start date and execution arn
             res.writeHead(200, {'Content-Type': 'application/json'});
-         
+
             res.end(JSON.stringify({
                 startDate: startDate,
                 executionArn: exeArn,


### PR DESCRIPTION
## ☕ Purpose

This PR fixes some minor bugs that I've found (and read some issues on the plugin repo) while trying to implement the `serverless-offline-step-functions` into our Serverless Application.

It has three major parts. The first one is the implementation of a parser that could also read LambdaFunction references, getting the `Fn::GetAtt` instead of the `arn`. This will allow parsing of functions that are being referenced like this:

~~~yaml
Resource:
  Fn::GetAtt: [TestLambdaFunction, Arn]
~~~

The second part of the PR fix some relative import issues on `state-machine-executor` and adds a simple integration with  `serverless-webpack`.

The third, and last, part is the addition of the `yamlParser` await while creating endpoints. This allow the usage of `{$file()}` and other Serverless commands inside the stepFunctions declaration.

## 🧐 Checklist

- [x] Added `getLambdaName` method on `index` to parse name from multiple parsers.
- [x] Added `getWebpackOrCommonFuction` on `state-machine-executor` to execute functions from `serverless-webpack`.
- [x] Fixed some relative imports on `state-machine-executor`.
- [x] Added a `Promise.resolve` wrapper to allow sync functions to be called on the `state-machine-executor`.
- [x] Added the `yamlParser`.
- [x] Improved the readability of the inputs and outputs.
